### PR TITLE
style(content): minor change to cheatsheet module style

### DIFF
--- a/components/Cheatsheet.module.scss
+++ b/components/Cheatsheet.module.scss
@@ -6,6 +6,8 @@
     box-shadow: var(--shadow);
     margin: 20px;
     background-color: var(--sec-bg-color);
+    text-decoration: none;
+    
 
     img {
         height: 150px;
@@ -19,8 +21,6 @@
         padding: 17px;
         color: white;
         font-size: 20px;
-        text-decoration: underline;
-        text-decoration-color: var(--sec-bg-color);
     }
 
     &:hover {

--- a/components/Cheatsheet.module.scss
+++ b/components/Cheatsheet.module.scss
@@ -19,9 +19,16 @@
         padding: 17px;
         color: white;
         font-size: 20px;
+        text-decoration: underline;
+        text-decoration-color: var(--sec-bg-color);
     }
 
     &:hover {
         box-shadow: var(--hover-shadow);
+
+        span {
+            color: var(--acc-color);
+            transition: 0.2s;
+        }
     }
 }


### PR DESCRIPTION
Le saque el subrayado a las opciones de cheatsheets porque en mi opinion, hacen más dificil de leerlo. 
(No pude sacarlo por completo asi que solo le cambie el color, seguramente haya una mejor manera)

Tambien le agregue un "hover" a las opciones, cambiando el color del nombre (span) a rosa